### PR TITLE
Update PureScript dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,11 +7,11 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.0.0",
-    "purescript-maybe": "^4.0.0"
+    "purescript-prelude": "^5.0.1",
+    "purescript-maybe": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-spec": "justinwoo/purescript-spec#compiler/0.12"
+    "purescript-spec": "^5.0.0"
   },
   "license": "MIT",
   "repository": {

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,14 +3,15 @@ module Test.Main where
 import Prelude
 
 import Effect (Effect)
+import Effect.Aff (launchAff_)
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (run)
+import Test.Spec.Runner (runSpec)
 import Text.Prettier (check, defaultOptions, format)
 
 main :: Effect Unit
-main = run [consoleReporter] do
+main = launchAff_ $ runSpec [consoleReporter] do
 
   describe "Prettier" do
 


### PR DESCRIPTION
This PR updates the various PureScript dependencies to their latest versions to ensure continued compatibility with the package set.

### Motivation

`prettier` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have these dependency issues resolved in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.